### PR TITLE
Remover entradas duplicadas

### DIFF
--- a/src/dbtools/removeDuplicates.js
+++ b/src/dbtools/removeDuplicates.js
@@ -1,0 +1,23 @@
+require("dotenv").config({ path: "../../.env" });
+require("../database")();
+
+const { CandidateModel } = require("../models");
+
+const removeDuplicates = async () => {
+  console.log("Removing duplicate candidates");
+  var previousID;
+  const candidates = await CandidateModel.find({}).sort("hoja_vida_id");
+  await Promise.all(
+    candidates.map(async (candidate) => {
+      var hoja_vida_id = candidate.hoja_vida_id;
+      if (hoja_vida_id == previousID) {
+        console.log(candidate.id_nombres, candidate.cargo_nombre);
+        candidate.remove();
+      }
+      previousID = hoja_vida_id;
+    })
+  );
+  console.log("Finished removing duplicate candidates");
+};
+
+removeDuplicates();

--- a/src/models/Candidate.js
+++ b/src/models/Candidate.js
@@ -222,6 +222,7 @@ const educationSchema = new Schema(
 
 const fileSchema = new Schema({
   expediente_id: Number,
+  expediente_estado: String,
   tipo_eleccion_id: Number,
   expediente_codigo: String,
   expediente_codigo_padre: String,
@@ -270,11 +271,13 @@ const candidateSchema = new Schema({
   cargo_nombre: String,
   candidato_id: Number,
   proceso_electoral_id: Number,
+  posicion: Number,
   org_politica_id: Number,
   org_politica_nombre: String,
   estado_nombre: String,
   estado_id: Number,
   hoja_vida: String,
+  enlace_foto: String,
   expediente: fileSchema,
   educacion: educationSchema,
   experiencia: experienceSchema,


### PR DESCRIPTION
Script para remover entradas duplicadas, se da en candidatos que son VPs, pues vienen en la data de congresistas y la de presidentes.