### PR TITLE
Fixes en updateEducacion / Nuevo udpateData

### DIFF
--- a/src/dbtools/updateData.js
+++ b/src/dbtools/updateData.js
@@ -1,0 +1,23 @@
+require("dotenv").config({ path: "../../.env" });
+require("../database")();
+
+const { CandidateModel } = require("../models");
+
+const updateData = async () => {
+  console.log("Start updating candidates data");
+
+  // Candidata Trans-género Gahela
+  await CandidateModel.updateOne(
+    { hoja_vida_id: 136670 },
+    {
+      $set: {
+        id_sexo: "F",
+        id_nombres: "GAHELA TSENEG",
+      },
+    }
+  );
+
+  console.log("Finished updating candidates data");
+};
+
+updateData();


### PR DESCRIPTION
updateEducacion
- Por la lógica usada, habían casos en los que una educación universitaria no concluida provocaba que no se evalúen otros niveles de educación. Entonces muchos candidatos terminaban con el nuevo campo en blanco.
- Se invirtió la lógica para recorrer todos los niveles posibles de educación, de menos a más, e ir reemplazando una variable local que contenga la máxima educación, y al final se haga un único update de DB por candidato.

updateData
- Para datos puntuales como el caso de Gahela, dado que hace campaña con ese nombre.