### PR TITLE
Conteos de sentencia por tipo

### DIFF
--- a/src/dbtools/updateSentencias.js
+++ b/src/dbtools/updateSentencias.js
@@ -5,7 +5,14 @@ const { CandidateModel } = require("../models");
 
 const resetCandidates = async () => {
   console.log("Resetting candidates");
-  const candidates = await CandidateModel.updateMany({}, { sentencias_ec: [] });
+  const candidates = await CandidateModel.updateMany(
+    {},
+    {
+      sentencias_ec: [],
+      sentencias_ec_penal_cnt: 0,
+      sentencias_ec_civil_cnt: 0,
+    }
+  );
 };
 
 resetCandidates();
@@ -30,7 +37,13 @@ fs.createReadStream("sentencias_input_data.csv")
           {
             hoja_vida_id: element.hoja_vida_id,
           },
-          { $push: { sentencias_ec: sentencia } }
+          {
+            $push: { sentencias_ec: sentencia },
+            $inc: {
+              sentencias_ec_civil_cnt: sentencia.tipo === "Civil" ? 1 : 0,
+              sentencias_ec_penal_cnt: sentencia.tipo === "Penal" ? 1 : 0,
+            },
+          }
         );
       })
     );

--- a/src/models/Candidate.js
+++ b/src/models/Candidate.js
@@ -289,6 +289,8 @@ const candidateSchema = new Schema({
   vacancia: { type: Boolean },
   experiencia_publica: { type: Boolean },
   sentencias_ec: [judgementsECSchema],
+  sentencias_ec_penal_cnt: { type: Number, default: 0 },
+  sentencias_ec_civil_cnt: { type: Number, default: 0 },
   org_politica_alias: String,
   educacion_mayor_nivel: String,
   // Campos obsoletos?


### PR DESCRIPTION
Añade conteos de sentencias por tipo.
Esto en principio es especialmente útil para luego exportar a mysql y hacer paneles de Grafana de una manera más sencilla.
Igual servirá como información hacia el front-end.