### PR TITLE
Reestructura preguntas para facilitar uso por parte de Front

### DIFF
--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -13,28 +13,33 @@ const getQuestions = async (params) => {
     topics = [topics];
   }
   let query =
-    "SELECT c.topico, b.codPregunta, b.pregunta, a.codRespuesta, a.respuesta FROM respuesta a INNER JOIN pregunta b ON a.codPregunta = b.codPregunta INNER JOIN topico c ON b.codTopico = c.codTopico WHERE b.codTopico IN (?)";
+    "SELECT c.codTopico, b.codPregunta, b.pregunta, a.codRespuesta, a.respuesta FROM respuesta a INNER JOIN pregunta b ON a.codPregunta = b.codPregunta INNER JOIN topico c ON b.codTopico = c.codTopico WHERE b.codTopico IN (?)";
 
   const response = await db.query(query, [topics]);
 
   let mapped = response.reduce(function(r, a) {
-    const { topico, codPregunta, pregunta, codRespuesta, respuesta } = a;
+    const { codTopico, codPregunta, pregunta, codRespuesta, respuesta } = a;
 
-    r[topico] = r[topico] || [];
+    r[codTopico] = r[codTopico] || [];
 
-    idx = r[topico].findIndex( element => element[codPregunta] === pregunta )
+    idx = r[codTopico].findIndex( element => element["question"]["id"] === codPregunta )
 
     if (idx < 0 ) {
-        r[topico].push({
-          [codPregunta]: pregunta,
-          respuestas : [{
-            [codRespuesta]:respuesta
+        r[codTopico].push({
+          question: {
+            id: codPregunta,
+            label: pregunta
+          },
+          answers : [{
+            id: codRespuesta,
+            label: respuesta
           }]
         });
     }else{
-        r[topico][idx]["respuestas"].push(
+        r[codTopico][idx]["answers"].push(
           {
-            [codRespuesta]:respuesta
+            id: codRespuesta,
+            label: respuesta
           }
         );
     }

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -423,7 +423,16 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["edu", "sal", "gob", "amb", "seg", "der", "cre", "imp"]
+                "enum": [
+                  "education", 
+                  "health", 
+                  "governability", 
+                  "environment", 
+                  "security",
+                  "rights",
+                  "growth",
+                  "taxes"
+                ]
               }
             },
             "required": true


### PR DESCRIPTION
Reestructura la entrega de las preguntas y respuestas con la route `/policies/questions?topics=health&topics=education`, para obtener un resultado similar al siguiente:
```
{
    "status": "Success",
    "statusCode": 200,
    "data": {
        "education": [
            {
                "question": {
                    "id": "edu1",
                    "label": "Pregunta 1"
                },
                "answers": [
                    {
                        "id": "a",
                        "label": "Respuesta a"
                    },
                    {
                        "id": "b",
                        "label": "Respuesta b"
                    },
                    {
                        "id": "c",
                        "label": "Respuesta c"
                    },
                    {
                        "id": "d",
                        "label": "Respuesta d"
                    },
                    {
                        "id": "e",
                        "label": "Respuesta e"
                    },
                    {
                        "id": "f",
                        "label": "Respuesta f
                    }
                ]
            },
            {
                "question": {
                    "id": "edu2",
                    "label": "¿Cómo mejorar la calidad de la educación escolar?"
                },
                "answers": [
                 ....
                ]
            },
           ...
        ],
        "health": [
            {
                "question": {
                    "id": "sal1",
                    "label": "Pregunta 1"
                },
                "answers": [
                    ...
                ]
            },
            ...
        ]
    },
    "message": "Información obtenida con éxito"
}