### PR TITLE
Create the algorithm to divide results by topic

### DIFF
--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -148,9 +148,11 @@ const getPolicyResults = async (body) => {
     return responsePresidentes.find((candidato) => item.org_politica_id === candidato.org_politica_id && candidato.cargo_id === cargoId);
   }
 
-  let queryPartidosSinCompatibilidad = "SELECT a.id AS org_politica_id, a.orden_cedula, a.nombre, a.alias FROM partidos_alias a WHERE a.id NOT IN (SELECT org_politica_id FROM partido_x_respuesta) ORDER BY a.alias ASC";
+  let listaIdPartidosObtenidos = partyList.map((item) => item.org_politica_id);
 
-  let responsePartidosSinCompatibilidad = await db.query(queryPartidosSinCompatibilidad);
+  let queryPartidosSinCompatibilidad = "SELECT a.id AS org_politica_id, a.orden_cedula, a.nombre, a.alias FROM partidos_alias a WHERE a.id NOT IN (?) AND a.id IN (SELECT org_politica_id FROM partido_x_respuesta) ORDER BY a.alias ASC";
+
+  let responsePartidosSinCompatibilidad = await db.query(queryPartidosSinCompatibilidad, [listaIdPartidosObtenidos]);
 
   let listaTotalPartidos = [...partyList, ...responsePartidosSinCompatibilidad];
 

--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -194,14 +194,15 @@ const getPolicyResults = async (body) => {
         //Find by topic if the party exists on the responses count list "groupedCountRespuestas"
         let itemPartyResponse = groupedCountRespuestas[topic].find((itemResp) => itemResp.org_politica_id === item.org_politica_id);
         if (itemPartyResponse) {
-          compatibilityObject[topic] = (itemPartyResponse.total / topicCounter[topic]).toFixed(2);
+          let topicCompatibility = (itemPartyResponse.total / topicCounter[topic]);
+          compatibilityObject[topic] = topicCompatibility ? +topicCompatibility.toFixed(2) : topicCompatibility;
           accumulatorByParty += itemPartyResponse.total;
         } else {
           compatibilityObject[topic] = 0;
         }
       }
-
-      let compatibility = (accumulatorByParty / totalCount).toFixed(2);
+      let totalCompatibility = (accumulatorByParty / totalCount);
+      let compatibility = totalCompatibility ? +totalCompatibility.toFixed(2) : totalCompatibility;
 
       return {
         name: item.alias,

--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -9,7 +9,7 @@ const getTopics = async () => {
 
 const getQuestions = async (params) => {
   if (params.topics.length < 1) {
-    const error = new Error("Se requiere al menos 1 tópico seleccionados.");
+    const error = new Error("Se requiere al menos 1 tópico seleccionado.");
     error.statusCode = 400;
     throw error;
   }
@@ -68,6 +68,15 @@ const getPolicyResults = async (body) => {
   const arrayPreguntas = body.answers.map(function (value) {
     questions.push(value.questionId);
     return [value.questionId, value.answerId];
+  });
+
+  //Validates if the response only has max. 2 answers by question
+  questions.forEach((item) => {
+    if (questions.filter(questionItem => questionItem === item).length > 2) {
+      const error = new Error("No está permitido más de 2 respuestas por pregunta.");
+      error.statusCode = 400;
+      throw error;
+    }
   });
 
   //List of parties obtained based on questions answered without agrupation and counting

--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -183,14 +183,15 @@ const getPolicyResults = async (body) => {
         }
       }
 
-      compatibilityObject.total = (accumulatorByParty / totalCount).toFixed(2);
+      let compatibility = (accumulatorByParty / totalCount).toFixed(2);
 
       return {
         name: item.alias,
         order: item.orden_cedula,
         org_politica_id: item.org_politica_id,
         org_politica_nombre: item.nombre,
-        compatibility: compatibilityObject,
+        compatibility,
+        compatibility_per_topic: compatibilityObject,
         president: presidenteData,
         firstVP: obtainPresidentByCargoId(2, item),
         secondVP: obtainPresidentByCargoId(3, item)
@@ -200,7 +201,7 @@ const getPolicyResults = async (body) => {
 
   //Remove null values for parties with no presidential leaders with filter
   //And sort the object list by the total compatibility
-  return results.filter((i) => i).sort((a, b) => b.compatibility.total - a.compatibility.total);
+  return results.filter((i) => i).sort((a, b) => b.compatibility - a.compatibility);
 };
 
 module.exports = {

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -538,33 +538,27 @@
                 "answers": [
                   {
                     "questionId": "edu1",
-                    "answerId": "a",
-                    "topic": "education"
+                    "answerId": "a"
                   },
                   {
                     "questionId": "edu2",
-                    "answerId": "b",
-                    "topic": "education"
+                    "answerId": "b"
                   },
                   {
                     "questionId": "edu3",
-                    "answerId": "a",
-                    "topic": "education"
+                    "answerId": "a"
                   },
                   {
                     "questionId": "sal1",
-                    "answerId": "a",
-                    "topic": "health"
+                    "answerId": "a"
                   },
                   {
-                    "questionId": "sal2",
-                    "answerId": "a",
-                    "topic": "health"
+                    "questionId": "sal1",
+                    "answerId": "b"
                   },
                   {
                     "questionId": "sal3",
-                    "answerId": "a",
-                    "topic": "health"
+                    "answerId": "a"
                   }
                 ]
               }

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -538,15 +538,33 @@
                 "answers": [
                   {
                     "questionId": "edu1",
-                    "answerId": "a"
+                    "answerId": "a",
+                    "topic": "education"
                   },
                   {
                     "questionId": "edu2",
-                    "answerId": "b"
+                    "answerId": "b",
+                    "topic": "education"
+                  },
+                  {
+                    "questionId": "edu3",
+                    "answerId": "a",
+                    "topic": "education"
                   },
                   {
                     "questionId": "sal1",
-                    "answerId": "c"
+                    "answerId": "a",
+                    "topic": "health"
+                  },
+                  {
+                    "questionId": "sal2",
+                    "answerId": "a",
+                    "topic": "health"
+                  },
+                  {
+                    "questionId": "sal3",
+                    "answerId": "a",
+                    "topic": "health"
                   }
                 ]
               }

--- a/src/utils/utilFunctions.js
+++ b/src/utils/utilFunctions.js
@@ -2,7 +2,7 @@ module.exports = {
   /**
    * The de-facto unbiased shuffle algorithm is the Fisher-Yates (aka Knuth) Shuffle.
    * See https://github.com/coolaj86/knuth-shuffle
-   * @param {*} array : Array to shuffle
+   * @param {*} array Array to shuffle
    * @returns  Shuffled array
    */
   shuffle: function (array) {
@@ -22,5 +22,19 @@ module.exports = {
     }
 
     return array;
+  },
+
+  /**
+   * Group an array of objects defined by a key on every object
+   * @param {*} array Array of objects to group
+   * @param {*} key key of every single object used to group
+   * @returns Object with the agrupation separated by values of the key provided
+   */
+  groupObjectListByKey(array, key) {
+    return array.reduce(function (r, a) {
+      r[a[key]] = r[a[key]] || [];
+      r[a[key]].push(a);
+      return r;
+    }, Object.create(null));
   }
 }

--- a/src/utils/utilFunctions.js
+++ b/src/utils/utilFunctions.js
@@ -30,7 +30,7 @@ module.exports = {
    * @param {*} key key of every single object used to group
    * @returns Object with the agrupation separated by values of the key provided
    */
-  groupObjectListByKey(array, key) {
+  groupObjectListByKey: function (array, key) {
     return array.reduce(function (r, a) {
       r[a[key]] = r[a[key]] || [];
       r[a[key]].push(a);


### PR DESCRIPTION
Se ha modificado la función `getPolicyResults` para separar la compatibilidad por tópico enviado.

Y enviando el response con el formato para cada partido:
`
{
      "name": "...",
      "org_politica_id": ...,
      "org_politica_nombre": "...",
      "compatibility": {
        "education": "0.67",
        "health": "1.00"
      },
      ...
}
`
