### PR TITLE
Questionary body structure change

### DIFF
--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -94,8 +94,6 @@ const getPolicyResults = async (body) => {
     }
   });
 
-  console.log(arrayPreguntas);
-
   //Validates if the response only has max. 2 answers by question
   questions.forEach((item) => {
     if (questions.filter(questionItem => questionItem === item).length > 2) {

--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -82,6 +82,7 @@ const getPolicyResults = async (body) => {
   let questions = [];
   let arrayPreguntas = [];
   body.answers.forEach(function (value) {
+    questions.push(value.questionId);
     if (value.answerId === null && value.answers.length > 0) {
       //Pregunta múltiple
       //answers: ['a', 'b']
@@ -91,15 +92,6 @@ const getPolicyResults = async (body) => {
       //answers: null
       //answerId: 'c'
       arrayPreguntas.push([value.questionId, value.answerId]);
-    }
-  });
-
-  //Validates if the response only has max. 2 answers by question
-  questions.forEach((item) => {
-    if (questions.filter(questionItem => questionItem === item).length > 2) {
-      const error = new Error("No está permitido más de 2 respuestas por pregunta.");
-      error.statusCode = 400;
-      throw error;
     }
   });
 

--- a/src/services/policiesService.js
+++ b/src/services/policiesService.js
@@ -80,10 +80,21 @@ const getQuestions = async (params) => {
 
 const getPolicyResults = async (body) => {
   let questions = [];
-  const arrayPreguntas = body.answers.map(function (value) {
-    questions.push(value.questionId);
-    return [value.questionId, value.answerId];
+  let arrayPreguntas = [];
+  body.answers.forEach(function (value) {
+    if (value.answerId === null && value.answers.length > 0) {
+      //Pregunta múltiple
+      //answers: ['a', 'b']
+      value.answers.forEach((answer) => arrayPreguntas.push([value.questionId, answer]));
+    } else if (value.answers === null && !!value.answerId) {
+      //Pregunta única
+      //answers: null
+      //answerId: 'c'
+      arrayPreguntas.push([value.questionId, value.answerId]);
+    }
   });
+
+  console.log(arrayPreguntas);
 
   //Validates if the response only has max. 2 answers by question
   questions.forEach((item) => {

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -538,27 +538,23 @@
                 "answers": [
                   {
                     "questionId": "edu1",
-                    "answerId": "a"
+                    "answerId": "a",
+                    "answers": null
                   },
                   {
                     "questionId": "edu2",
-                    "answerId": "b"
-                  },
-                  {
-                    "questionId": "edu3",
-                    "answerId": "a"
+                    "answerId": null,
+                    "answers": ["a", "b"]
                   },
                   {
                     "questionId": "sal1",
-                    "answerId": "a"
-                  },
-                  {
-                    "questionId": "sal1",
-                    "answerId": "b"
+                    "answerId": null,
+                    "answers": ["a", "c"]
                   },
                   {
                     "questionId": "sal3",
-                    "answerId": "a"
+                    "answerId": "a",
+                    "answers": null
                   }
                 ]
               }


### PR DESCRIPTION
Nueva estructura para el payload del POST:
➡️ [Issue de Frontend relacionado](https://github.com/openpolitica/open-wizard/pull/315)
Ahora se admiten preguntas múltiples obteniendo las respuestas en un array.

Una pregunta multi con 1 alternativa seleccionada
{
answerId: null,
answers: ['d'],
}

Una pregunta multi con 2 alternativas seleccionadas
{
answerId: null,
answers: ['d', 'e'],
}

Una pregunta single
{
answerId: 'd',
answers: null,
}