### PR TITLE
Actualiza cuenta oficial de twitter para Pedro Castillo

### DIFF
--- a/src/dbtools/redes_sociales.csv
+++ b/src/dbtools/redes_sociales.csv
@@ -16,4 +16,4 @@ hoja_vida_id,facebook,twitter
 137291,https://www.facebook.com/DanielUrrestiElera,https://twitter.com/DanielUrresti1
 137542,https://www.facebook.com/GeorgeForsythVN,https://twitter.com/George_Forsyth
 137760,https://www.facebook.com/ollantahumala,https://twitter.com/Ollanta_HumalaT
-137792,https://www.facebook.com/PedroCastilloPresidente2021,https://twitter.com/PedroCastilloPL
+137792,https://www.facebook.com/PedroCastilloPresidente2021,https://twitter.com/PedroCastilloTe


### PR DESCRIPTION
Se actualiza la cuenta oficial de twitter para Pedro Castillo, según esta nota:
https://elcomercio.pe/politica/elecciones/pedro-castillo-aclaran-que-partido-peru-libre-no-tiene-cuenta-oficial-de-twitter-elecciones-2021-noticia/